### PR TITLE
shorthand binding syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,11 @@ function bindModel(attributes, children, type) {
 
   var binding = inputTypeBindings[type] || bindTextInput;
 
-  binding(attributes, children, attributes.binding.get, refreshFunction(attributes.binding.set));
+  var bindingAttr = attributes.binding;
+  if (bindingAttr instanceof Array) {
+    bindingAttr = exports.bind(bindingAttr[0], bindingAttr[1]);
+  }
+  binding(attributes, children, bindingAttr.get, refreshFunction(bindingAttr.set));
 }
 
 function inputType(selector, attributes) {

--- a/test/plastiqSpec.js
+++ b/test/plastiqSpec.js
@@ -215,6 +215,24 @@ describe('plastiq', function () {
       });
     });
 
+    it('can bind with a shorthand binding syntax', function () {
+      function render(model) {
+        return h('div',
+          h('input', {type: 'text', binding: [model, 'text']}),
+          h('span', model.text)
+        );
+      }
+
+      attach(render, {text: ''});
+
+      find('input').sendkeys('omg');
+
+      return retry(function() {
+        expect(find('span').text()).to.equal('omg');
+        expect(find('input').val()).to.equal('omg');
+      });
+    });
+
     it('can bind to a text input and oninput', function () {
       function render(model) {
         return h('div',


### PR DESCRIPTION
Shortens:

``` JavaScript
var bind = plastiq.bind;
h('input', {type: 'text', binding: bind(model, 'property')});
```

to:

``` JavaScript
h('input', {type: 'text', binding: [model, 'property'])});
```

for the lazy.
