### PR TITLE
ViewModel string binding syntax?

### DIFF
--- a/rendering.js
+++ b/rendering.js
@@ -470,9 +470,12 @@ exports.html.refreshAfter = refreshAfter;
 exports.html.norefresh = norefresh;
 
 function makeBinding(b, options) {
-  var binding = b instanceof Array
-    ?  bindingObject.apply(undefined, b)
-    : b;
+  var binding = b;
+  if (b instanceof Array) {
+    binding = bindingObject.apply(undefined, b);
+  } else if (typeof b === 'string') {
+    throw new Error('Binding value cannot be a string')
+  }
 
   binding.set = refreshify(binding.set, options);
 

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -599,6 +599,28 @@ describe('hyperdom', function () {
       });
     });
 
+    it('can bind to an attribute of the viewModel', function () {
+      function ViewModel() {
+        this.text = ''
+      }
+
+      ViewModel.prototype.render = function render() {
+        return h('div',
+          h('input', {type: 'text', binding: 'text'}),
+          h('span', this.text)
+        );
+      }
+
+      attach(new ViewModel());
+
+      find('input').sendkeys('haha');
+
+      return retry(function() {
+        expect(find('span').text()).to.equal('haha');
+        expect(find('input').val()).to.equal('haha');
+      });
+    });
+
     describe('setting input values on reused DOM elements', function () {
       it('checkbox', function () {
         function render(model) {


### PR DESCRIPTION
Not ready to merge, posting this for feedback.

Since we are deprecating render functions, we should mostly be able to lose the weird `[model, 'property']` binding syntax in favour of just `'property'`, because ViewModels are usually binding to `this`, e.g:

```js
// instead of:
class ViewModel {
  render() {
    return h('input', { type: 'text', binding: [this, 'text'] })
  }
}

// ...can we do this now?
class ViewModel {
  render() {
    return h('input', { type: 'text', binding: 'text' })
  }
}
```

Wrote a failing test but got a bit lost trying to make it pass :) -- what do you think of this idea?