### PR TITLE
Vdom outside render loop

### DIFF
--- a/bindModel.js
+++ b/bindModel.js
@@ -1,5 +1,6 @@
 var listener = require('./listener');
 var binding = require('./binding')
+var RefreshHook = require('./render').RefreshHook
 
 module.exports = function(tag, attributes, children) {
   var type = inputType(tag, attributes)
@@ -140,7 +141,11 @@ function insertEventHandler(attributes, eventName, handler) {
 function sequenceFunctions(handler1, handler2) {
   return function (ev) {
     handler1(ev);
-    return handler2(ev);
+    if (handler2 instanceof RefreshHook) {
+      return handler2.handler(ev);
+    } else {
+      return handler2(ev);
+    }
   };
 }
 

--- a/binding.js
+++ b/binding.js
@@ -1,4 +1,4 @@
-var refreshify = require('./refreshify');
+var refreshify = require('./render').refreshify;
 var meta = require('./meta');
 
 module.exports = function(b, options) {

--- a/component.js
+++ b/component.js
@@ -2,14 +2,10 @@ var hyperdomMeta = require('./meta');
 var render = require('./render');
 
 function Component(model, options) {
-  var currentRender = render.currentRender();
-
   this.isComponent = options && options.hasOwnProperty('component') && options.component
-  this.currentRender = currentRender;
   this.model = model;
   this.key = model.renderKey;
   this.component = undefined;
-  this.mount = currentRender.mount;
 }
 
 Component.prototype.type = 'Widget';
@@ -22,7 +18,8 @@ Component.prototype.init = function () {
   var meta = hyperdomMeta(this.model);
   meta.components.add(this);
 
-  this.component = this.currentRender.mount.createDomComponent()
+  var currentRender = render.currentRender();
+  this.component = currentRender.mount.createDomComponent()
   var element = this.component.create(vdom);
 
   if (self.model.onbeforeadd) {
@@ -34,7 +31,7 @@ Component.prototype.init = function () {
   }
 
   if (self.model.onadd || self.model.onrender) {
-    this.currentRender.finished.then(function () {
+    currentRender.finished.then(function () {
       if (self.model.onadd) {
         self.model.onadd(self.component.element);
       }
@@ -85,7 +82,8 @@ Component.prototype.update = function (previous) {
 
 
   if (self.model.onupdate || self.model.onrender) {
-    this.currentRender.finished.then(function () {
+    var currentRender = render.currentRender();
+    currentRender.finished.then(function () {
       afterUpdate(self.model, self.component.element, oldElement)
     });
   }
@@ -105,7 +103,8 @@ Component.prototype.update = function (previous) {
 };
 
 Component.prototype.render = function () {
-  return this.mount.renderComponent(this.model);
+  var currentRender = render.currentRender();
+  return currentRender.mount.renderComponent(this.model);
 };
 
 Component.prototype.refresh = function () {
@@ -127,7 +126,8 @@ Component.prototype.destroy = function (element) {
   }
 
   if (self.model.onremove) {
-    this.currentRender.finished.then(function () {
+    var currentRender = render.currentRender();
+    currentRender.finished.then(function () {
       self.model.onremove(element);
     });
   }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var rendering = require('./rendering')
-var refreshify = require('./refreshify')
 var binding = require('./binding')
 var meta = require('./meta');
 var render = require('./render')
@@ -7,7 +6,7 @@ var refreshEventResult = require('./refreshEventResult')
 var Component = require('./component')
 
 exports.html = rendering.html;
-exports.html.refreshify = refreshify
+exports.html.refreshify = render.refreshify
 exports.rawHtml = rendering.rawHtml
 exports.jsx = rendering.jsx;
 exports.attach = rendering.attach;
@@ -16,7 +15,7 @@ exports.append = rendering.append;
 exports.appendVDom = rendering.appendVDom;
 exports.binding = binding;
 exports.meta = meta;
-exports.refreshify = refreshify;
+exports.refreshify = render.refreshify;
 exports.norefresh = refreshEventResult.norefresh;
 exports.component = function(model) {
   return new Component(model, {component: true})

--- a/listener.js
+++ b/listener.js
@@ -1,4 +1,4 @@
-var refreshify = require('./refreshify');
+var refreshify = require('./render').refreshify;
 
 function ListenerHook(listener) {
   this.listener = refreshify(listener);

--- a/mount.js
+++ b/mount.js
@@ -5,7 +5,6 @@ var Set = require('./set');
 var refreshEventResult = require('./refreshEventResult')
 var vtext = require("virtual-dom/vnode/vtext.js")
 var PropertyHook = require('./propertyHook');
-var Component = require('./component')
 
 var lastId = 0;
 

--- a/refreshAfter.js
+++ b/refreshAfter.js
@@ -1,5 +1,5 @@
 var deprecations = require('./deprecations');
-var refreshify = require('./refreshify');
+var refreshify = require('./render').refreshify;
 
 module.exports = function(promise) {
   deprecations.refreshAfter('hyperdom.html.refreshAfter is deprecated');

--- a/refreshify.js
+++ b/refreshify.js
@@ -1,5 +1,0 @@
-var render = require('./render');
-
-module.exports = function(fn, options) {
-  return render.currentRender().mount.refreshify(fn, options)
-}

--- a/render.js
+++ b/render.js
@@ -24,10 +24,13 @@ Render.prototype.transformFunctionAttribute = function() {
 }
 
 module.exports = runRender
+module.exports.currentRender = currentRender
+module.exports.refreshify = refreshify
+module.exports.RefreshHook = RefreshHook
 
-runRender.currentRender = function () {
+function currentRender () {
   return runRender._currentRender || defaultRender;
-};
+}
 
 var defaultRender = {
   mount: {
@@ -36,6 +39,22 @@ var defaultRender = {
   },
 
   transformFunctionAttribute: function (key, value) {
-    return value
+    return new RefreshHook(value)
   }
+}
+
+function refreshify(fn, options) {
+  return runRender.currentRender().mount.refreshify(fn, options)
+}
+
+function RefreshHook(handler) {
+  this.handler = handler
+}
+
+RefreshHook.prototype.hook = function (node, property) {
+  node[property] = refreshify(this.handler)
+}
+
+RefreshHook.prototype.unhook = function (node, property) {
+  node[property] = null
 }

--- a/router.js
+++ b/router.js
@@ -1,5 +1,5 @@
 var makeBinding = require('./binding')
-var refreshify = require('./refreshify')
+var refreshify = require('./render').refreshify;
 var runRender = require('./render')
 var h = require('./rendering').html
 

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -694,6 +694,37 @@ describe('hyperdom', function () {
         });
       });
     })
+
+    it('can render components outside of the render loop', function () {
+      var model = {
+        button: h('div',
+          {
+            render: function () {
+              return h('button', {
+                onclick: function () {
+                  model.on = true;
+                }
+              })
+            }
+          }
+        ),
+
+        render: function () {
+          return h('div',
+            this.button,
+            model.on? h('span', 'on'): undefined
+          );
+        }
+      }
+
+      attach(model);
+
+      return click('button').then(function () {
+        return retry(function () {
+          expect(find('span').text()).to.eql('on');
+        });
+      });
+    })
   })
 
   describe('norefresh', function () {

--- a/test/server/detachedRenderingSpec.js
+++ b/test/server/detachedRenderingSpec.js
@@ -24,9 +24,9 @@ describe('hyperdom', function() {
       );
       var html = vdomToHtml(vdom);
       expect(html).to.equal('<div class="outer"><div class="inner"></div><div class="component"></div><div><span>some raw HTML</span></div></div>');
-      vdom.children[0].properties.onclick();
+      vdom.children[0].properties.onclick.handler();
       expect(model.counter).to.equal(1);
-      vdom.children[0].properties.onclick();
+      vdom.children[0].properties.onclick.handler();
       expect(model.counter).to.equal(2);
     });
 

--- a/test/server/storeCacheSpec.js
+++ b/test/server/storeCacheSpec.js
@@ -2,7 +2,7 @@ var serverRenderCache = require('../../serverRenderCache')
 var StoreCache = require('../../storeCache')
 var render = require('../../render')
 var expect = require('chai').expect
-var refreshify = require('../../refreshify')
+var refreshify = require('../../render').refreshify;
 
 describe('store cache', function () {
   var storeCache


### PR DESCRIPTION
This fixed an issue that has been with hyperdom/plastiq since the beginning. DOM event handlers have always needed to refresh the view after they run, and to do this they needed to have been recognised during the render loop. A consequence of this was that defining VDOM with event handlers outside of the render loop meant that those event handlers didn't refresh the view, which is annoying and a bit confusing.

This PR fixes that issue. Now, VDOM with event handlers can be prepared beforehand, outside the render loop, statically, and be used in various places in the VDOM. This allows VDOM to be defined once and reused - which can dramatically improve performance.

CC @dereke 