### PR TITLE
simpler routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chai": "3.5.0",
     "detect-browser": "1.6.2",
     "electron": "1.6.2",
+    "electron-mocha": "3.4.0",
     "hyperx": "2.3.0",
     "jquery": "2.1.3",
     "jquery-sendkeys": "4.0.0",

--- a/test/browser/mountHyperdom.js
+++ b/test/browser/mountHyperdom.js
@@ -14,6 +14,22 @@ function createTestDiv () {
   return div
 }
 
+function createReloadButton (href) {
+  var link = document.createElement('a')
+  link.href = href
+  link.innerText = '⟳ reload'
+  link.style = 'z-index: 1000;' +
+    'position: fixed;' +
+    'right: 5px;' +
+    'bottom: 5px;'
+
+  return link
+}
+
+window.addEventListener('onload', function () {
+  document.body.append(createReloadButton(window.location.href))
+})
+
 module.exports = function (app, options) {
   var testDiv = createTestDiv()
   if (options && (options.hash || options.url) && options.router) {


### PR DESCRIPTION
```jsx
var hyperdom = require('hyperdom')
var router = require('hyperdom/router')

var home = router.route('/')
var user = router.route('/user')
var userSettings = router.route('/user/settings')

class App {
  constructor() {
    this.user = new UserView()
  }

  routes() {
    return [
      home({
        render: () => <h1>home</h1>
      }),

      // we put the UserView sub-component into the routes array
      // so UserView can handle its own routing
      this.user
    ]
  }

  render(content) {
    // this is called with the output of the routes
    // and acts as a master page layout
    return <div>
      <menu>app menu</menu>
      {content}
    </div>
  }
}

class UserView {
  routes() {
    return [
      user({
        render: () => <h2>user</h2>
      })

      userSettings({
        render: () => <h2>user settings</h2>
      })
    ]
  }

  render(content) {
    return <div>
      <h1>hi {this.name}</h1>
      {content}
    </div>
  }
}
```

The point of this is:
* we can put sub components in the array of routes, these components have their own `routes()` methods.
* we do away with individual routes having inner routes, which was a bit mental
* all routes are effectively static, you can't setup new routes in `onload` etc, although you can of course return new routing as the app state evolves.
* if a component has both `render()` and `routes()` methods, the `render(content)` acts as a wrapper, or master page for what is rendered from routes.