### PR TITLE
hyperdom.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 var rendering = require('./rendering')
-var binding = require('./binding')
-var meta = require('./meta')
 var render = require('./render')
-var refreshEventResult = require('./refreshEventResult')
 var Component = require('./component')
 
 exports.html = rendering.html
@@ -13,10 +10,11 @@ exports.attach = rendering.attach
 exports.replace = rendering.replace
 exports.append = rendering.append
 exports.appendVDom = rendering.appendVDom
-exports.binding = binding
-exports.meta = meta
+exports.binding = require('./binding')
+exports.meta = require('./meta')
 exports.refreshify = render.refreshify
-exports.norefresh = refreshEventResult.norefresh
+exports.norefresh = require('./refreshEventResult').norefresh
+exports.join = require('./join')
 exports.component = function (model) {
   return new Component(model, {component: true})
 }

--- a/join.js
+++ b/join.js
@@ -1,0 +1,11 @@
+module.exports = function join (array, separator) {
+  var output = []
+  for (var i = 0, l = array.length; i < l; i++) {
+    var item = array[i]
+    if (i > 0) {
+      output.push(separator)
+    }
+    output.push(item)
+  }
+  return output
+}

--- a/readme.md
+++ b/readme.md
@@ -286,6 +286,21 @@ or
 h('div', {dataset: {stuff: 'something'}});
 ```
 
+### Joining VDOM Arrays
+
+You may have an array of vdom elements that you want to join together with a separator, something very much like `Array.prototype.join()`, but for vdom. 
+
+```jsx
+var items = ['one', 'two', 'three']
+hyperdom.join(items.map(i => <code>{i}</code>), ', ')
+```
+
+Will produce this HTML:
+
+```html
+<code>one</code>, <code>two</code>, <code>three</code>
+```
+
 ## Responding to Events
 
 Pass a function to any `on*` event handler.

--- a/test/server/joinSpec.js
+++ b/test/server/joinSpec.js
@@ -1,0 +1,18 @@
+/* eslint-env mocha */
+
+var expect = require('chai').expect
+var toHtml = require('../../toHtml')
+var join = require('../../join')
+var h = require('../..').html
+
+describe('join', function () {
+  it('can join an array of vdom by a separator', function () {
+    expect(toHtml(h('div',
+      join([
+        h('code', 'one'),
+        h('code', 'two'),
+        h('code', 'three')
+      ], ' ')
+    ))).to.equal('<div><code>one</code> <code>two</code> <code>three</code></div>')
+  })
+})


### PR DESCRIPTION
### Joining VDOM Arrays

You may have an array of vdom elements that you want to join together with a separator, something very much like `Array.prototype.join()`, but for vdom. 

```jsx
var items = ['one', 'two', 'three']
hyperdom.join(items.map(i => <code>{i}</code>), ', ')
```

Will produce this HTML:

```html
<code>one</code>, <code>two</code>, <code>three</code>
```