### PR TITLE
production mode

### DIFF
--- a/debuggingProperties.js
+++ b/debuggingProperties.js
@@ -3,7 +3,7 @@ var PropertyHook = require('./propertyHook')
 var VirtualNode = require('virtual-dom/vnode/vnode')
 
 module.exports = function (vdom, model) {
-  if (vdom && vdom.constructor === VirtualNode) {
+  if (process.env.NODE_ENV !== 'production' && vdom && vdom.constructor === VirtualNode) {
     if (!vdom.properties) {
       vdom.properties = {}
     }

--- a/deprecations.js
+++ b/deprecations.js
@@ -2,7 +2,7 @@ function deprecationWarning () {
   var warningIssued = false
 
   return function (arg) {
-    if (!warningIssued) {
+    if (process.env.NODE_ENV !== 'production' && !warningIssued) {
       console.warn(arg)
       warningIssued = true
     }
@@ -16,5 +16,8 @@ module.exports = {
   renderFunction: deprecationWarning(),
   norefresh: deprecationWarning(),
   mapBinding: deprecationWarning(),
-  viewComponent: deprecationWarning()
+  viewComponent: deprecationWarning(),
+  htmlRawHtml: deprecationWarning(),
+  htmlBinding: deprecationWarning(),
+  refreshAfter: deprecationWarning()
 }

--- a/prepareAttributes.js
+++ b/prepareAttributes.js
@@ -45,7 +45,7 @@ module.exports = function (tag, attributes, childElements) {
     }
   }
 
-  if (attributes.__source) {
+  if (process.env.NODE_ENV !== 'production' && attributes.__source) {
     if (!dataset) {
       dataset = attributes.dataset
 

--- a/readme.md
+++ b/readme.md
@@ -1132,6 +1132,14 @@ Will generate
 <h1 data-file-name="/full/path/to/file.jsx" data-line-number="40">Title</h1>
 ```
 
+# Production Build
+
+Debugging features and deprecation warnings can be turned off for production builds. Hyperdom source code checks the `NODE_ENV` environment variable, and when set to `production` will turn these features off.
+
+To make a production build with webpack, use `webpack -p`.
+
+To make a production build with browserify, use [envify](https://github.com/hughsk/envify) and ensure `NODE_ENV=production`, for e.g. `browserify -t [ envify --NODE_ENV production  ] ...` and then use a minifier like [uglify](https://github.com/mishoo/UglifyJS2) to strip the disabled code.
+
 # Common Errors
 
 ## Outside Render Cycle

--- a/rendering.js
+++ b/rendering.js
@@ -152,17 +152,17 @@ Object.defineProperty(exports.html, 'refresh', {get: function () {
 }})
 
 Object.defineProperty(exports.html, 'norefresh', {get: function () {
-  deprecations.refresh('hyperdom.html.norefresh is deprecated, please use hyperdom.norefresh() instead')
+  deprecations.norefresh('hyperdom.html.norefresh is deprecated, please use hyperdom.norefresh() instead')
   return refreshEventResult.norefresh
 }})
 
 Object.defineProperty(exports.html, 'binding', {get: function () {
-  deprecations.refresh('hyperdom.html.binding() is deprecated, please use hyperdom.binding() instead')
+  deprecations.htmlBinding('hyperdom.html.binding() is deprecated, please use hyperdom.binding() instead')
   return binding
 }})
 
 Object.defineProperty(exports.html, 'refreshAfter', {get: function () {
-  deprecations.refresh("hyperdom.html.refreshAfter() is deprecated, please use require('hyperdom/refreshAfter')() instead")
+  deprecations.refreshAfter("hyperdom.html.refreshAfter() is deprecated, please use require('hyperdom/refreshAfter')() instead")
   return refreshAfter
 }})
 
@@ -188,7 +188,7 @@ function rawHtml () {
 }
 
 exports.html.rawHtml = function () {
-  console.warn('hyperdom.html.rawHtml() is deprecated, please use hyperdom.rawHtml() instead')
+  deprecations.htmlRawHtml('hyperdom.html.rawHtml() is deprecated, please use hyperdom.rawHtml() instead')
   return rawHtml.apply(undefined, arguments)
 }
 

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -536,7 +536,7 @@ describe('hyperdom', function () {
     })
 
     if (detect.dataset) {
-      describe('source locations', () => {
+      describe('source locations', function () {
         it('generates filename and line number from __source attribute', function () {
           function render () {
             return h('div', {__source: {fileName: '/full/path/to/file.jsx', lineNumber: 80}})
@@ -2138,7 +2138,7 @@ describe('hyperdom', function () {
 
   describe('component debugger', function () {
     contextInProduction(function () {
-      it('does not set debugging properties', () => {
+      it('does not set debugging properties', function () {
         var inner = {
           render: function () {
             return h('div.inner', 'inner')
@@ -3024,11 +3024,11 @@ function wait (n) {
 
 function contextInProduction (fn) {
   context('when NODE_ENV=production', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       process.env.NODE_ENV = 'production'
     })
 
-    afterEach(() => {
+    afterEach(function () {
       delete process.env.NODE_ENV
     })
 

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -536,15 +536,30 @@ describe('hyperdom', function () {
     })
 
     if (detect.dataset) {
-      it('generates filename and line number from __source attribute', function () {
-        function render () {
-          return h('div', {__source: {fileName: '/full/path/to/file.jsx', lineNumber: 80}})
-        }
+      describe('source locations', () => {
+        it('generates filename and line number from __source attribute', function () {
+          function render () {
+            return h('div', {__source: {fileName: '/full/path/to/file.jsx', lineNumber: 80}})
+          }
 
-        attach(render, {})
+          attach(render, {})
 
-        expect(find('div').data('file-name')).to.eql('/full/path/to/file.jsx')
-        expect(find('div').data('line-number')).to.eql(80)
+          expect(find('div').data('file-name')).to.eql('/full/path/to/file.jsx')
+          expect(find('div').data('line-number')).to.eql(80)
+        })
+
+        contextInProduction(function () {
+          it('does not generate filename and line number', function () {
+            function render () {
+              return h('div', {__source: {fileName: '/full/path/to/file.jsx', lineNumber: 80}})
+            }
+
+            attach(render, {})
+
+            expect(find('div').data('file-name')).to.eql(undefined)
+            expect(find('div').data('line-number')).to.eql(undefined)
+          })
+        })
       })
     }
 
@@ -2122,6 +2137,27 @@ describe('hyperdom', function () {
   })
 
   describe('component debugger', function () {
+    contextInProduction(function () {
+      it('does not set debugging properties', () => {
+        var inner = {
+          render: function () {
+            return h('div.inner', 'inner')
+          }
+        }
+
+        var outer = {
+          render: function () {
+            return h('div.outer', 'outer', inner)
+          }
+        }
+
+        attach(outer)
+
+        expect(find('.outer')[0]._hyperdomMeta).to.eql(undefined)
+        expect(find('.inner')[0]._hyperdomMeta).to.eql(undefined)
+      })
+    })
+
     it('sets the component to the element', function () {
       var inner = {
         render: function () {
@@ -2983,5 +3019,19 @@ describe('hyperdom', function () {
 function wait (n) {
   return new Promise(function (resolve) {
     setTimeout(resolve, n)
+  })
+}
+
+function contextInProduction (fn) {
+  context('when NODE_ENV=production', function () {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    afterEach(() => {
+      delete process.env.NODE_ENV
+    })
+
+    fn()
   })
 }


### PR DESCRIPTION
remove debugging features and warnings for production use.

* doesn't write information used by Chrome Hyperdom Inspector
* doesn't `console.warn` on deprecations
* doesn't attempt to set `data-filename` and `data-linenumber`

You can invoke this by running `webpack -p` or using the `envify` browserify transform with `NODE_ENV=production`.

- [x] documentation