### PR TITLE
Invisible component refresh fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": [
     "standard",
     "plugin:es5/no-es2015"
-  ]
+  ],
+  "rules": {
+    "no-console": "error"
+  }
 }

--- a/component.js
+++ b/component.js
@@ -121,8 +121,10 @@ Component.prototype.renderModel = function (oldElement) {
 Component.prototype.render = function (oldElement) {
   var model = this.model
 
+  var meta = hyperdomMeta(model)
+  meta.lastRenderId = render.currentRender().mount.renderId
+
   if (typeof model.renderCacheKey === 'function') {
-    var meta = hyperdomMeta(model)
     var key = model.renderCacheKey()
     if (key !== undefined && meta.cacheKey === key && meta.cachedVdom) {
       return meta.cachedVdom
@@ -136,11 +138,13 @@ Component.prototype.render = function (oldElement) {
 }
 
 Component.prototype.refresh = function () {
-  var oldElement = this.component.element
-
-  beforeUpdate(this.model, oldElement)
-  this.component.update(this.render())
-  afterUpdate(this.model, this.component.element, oldElement)
+  var currentRender = render.currentRender()
+  if (currentRender.mount.isComponentInDom(this.model)) {
+    var oldElement = this.component.element
+    beforeUpdate(this.model, oldElement)
+    this.component.update(this.render())
+    afterUpdate(this.model, this.component.element, oldElement)
+  }
 }
 
 Component.prototype.destroy = function (element) {

--- a/deprecations.js
+++ b/deprecations.js
@@ -3,7 +3,7 @@ function deprecationWarning () {
 
   return function (arg) {
     if (process.env.NODE_ENV !== 'production' && !warningIssued) {
-      console.warn(arg)
+      console.warn(arg) // eslint-disable-line no-console
       warningIssued = true
     }
   }

--- a/mount.js
+++ b/mount.js
@@ -18,6 +18,7 @@ function Mount (model, options) {
   this.mountRenderRequested = false
   this.componentRendersRequested = undefined
   this.id = ++lastId
+  this.renderId = 0
   this.mounted = true
   this.router = router
 }
@@ -85,6 +86,7 @@ Mount.prototype.refreshImmediately = function () {
   var self = this
 
   runRender(self, function () {
+    self.renderId++
     var vdom = self.render()
     self.component.update(vdom)
     self.mountRenderRequested = false
@@ -110,6 +112,11 @@ Mount.prototype.refreshComponent = function (component) {
 
   this.componentRendersRequested.push(component)
   this.queueRender()
+}
+
+Mount.prototype.isComponentInDom = function (component) {
+  var meta = hyperdomMeta(component)
+  return meta.lastRenderId === this.renderId
 }
 
 Mount.prototype.setupModelComponent = function (model) {

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -1594,6 +1594,49 @@ describe('hyperdom', function () {
       })
     })
 
+    it('does not refresh if the component was not rendered', function () {
+      var model = {
+        showModel: 1,
+
+        model1: innerModel('one'),
+        model2: innerModel('two'),
+
+        render: function () {
+          return h('div', this.showModel === 1 ? this.model1 : this.model2)
+        }
+      }
+
+      function innerModel (name) {
+        return {
+          name: name,
+
+          render: function () {
+            return h('h1', 'hi ' + this.name)
+          }
+        }
+      }
+
+      attach(model)
+
+      expect(find('h1').text()).to.equal('hi one')
+
+      model.showModel = 2
+      model.refresh()
+
+      return retry(function () {
+        expect(find('h1').text()).to.equal('hi two')
+      }).then(function () {
+        model.model1.name = 'one updated'
+        model.model1.refreshComponent()
+      }).then(function () {
+        return wait(10)
+      }).then(function () {
+        return retry(function () {
+          expect(find('h1').text()).to.equal('hi two')
+        })
+      })
+    })
+
     it('a component can be represented several times and be refreshed', function () {
       var model = {
         models: 1,


### PR DESCRIPTION
Situation where a component (A) is rendered to a DIV, then it is not rendered, with another component (B) using the same DIV. When component A is re-rendered using `refreshComponent()`, the component A renders over the top of component B. This introduces a fix where we don't re-render a component with `refreshComponent()` if we know it wasn't part of the last render cycle.