### PR TITLE
rewrite className -> class when rendering svg

### DIFF
--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -634,6 +634,18 @@ describe('hyperdom', function () {
       expect(find('div button span.title').text()).to.equal('button title')
     })
 
+    it('renders svg classes', function () {
+      function render () {
+        return jsx('svg', {xmlns: 'http://www.w3.org/2000/svg', width: '300', height: '300'}, [
+          jsx('circle', {class: 'svg-circle'})
+        ])
+      }
+
+      attach(render, {})
+
+      expect(find('.svg-circle').length).to.eql(1)
+    })
+
     it('renders view components without attributes', function () {
       function CoolButton (properties, children) {
         this.properties = properties

--- a/test/server/hyperxSpec.js
+++ b/test/server/hyperxSpec.js
@@ -8,4 +8,7 @@ describe('hyperx', function () {
   it('can render with hyperx', function () {
     expect(toHtml(hx`<div>hi</div>`)).to.equal('<div>hi</div>') // eslint-disable-line es5/no-template-literals
   })
+  it('can render svg with class with hyperx', function () {
+    expect(toHtml(hx`<svg><rect class="hello"></rect></svg>`)).to.equal('<svg><rect class="hello"></rect></svg>') // eslint-disable-line es5/no-template-literals
+  })
 })

--- a/xml.js
+++ b/xml.js
@@ -2,6 +2,7 @@ var AttributeHook = require('virtual-dom/virtual-hyperscript/hooks/attribute-hoo
 
 var namespaceRegex = /^([a-z0-9_-]+)(--|:)([a-z0-9_-]+)$/i
 var xmlnsRegex = /^xmlns(--|:)([a-z0-9_-]+)$/i
+var SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
 
 function transformTanName (vnode, namespaces) {
   var tagNamespace = namespaceRegex.exec(vnode.tagName)
@@ -32,10 +33,15 @@ function transformProperties (vnode, namespaces) {
           properties[match[1] + ':' + match[3]] = new AttributeHook(namespaces[match[1]], properties[key])
           delete properties[key]
         } else {
-          var property = properties[key]
-          var type = typeof property
-          if (type === 'string' || type === 'number' || type === 'boolean') {
-            attributes[key] = property
+          if (vnode.namespace === SVG_NAMESPACE && key === 'className') {
+            attributes['class'] = properties.className
+            delete properties.className
+          } else {
+            var property = properties[key]
+            var type = typeof property
+            if (type === 'string' || type === 'number' || type === 'boolean') {
+              attributes[key] = property
+            }
           }
         }
       }


### PR DESCRIPTION
When rendering an svg element containing a `class` attribute they attribute gets rewritten as `className`.
This change switches it back to `class`