### PR TITLE
Call functions passed to hyperdom.html

### DIFF
--- a/rendering.js
+++ b/rendering.js
@@ -102,16 +102,15 @@ exports.html = function (hierarchySelector) {
   var attributes = arguments[1]
 
   if (attributes && attributes.constructor === Object && typeof attributes.render !== 'function') {
-    childElements = toVdom.recursive(Array.prototype.slice.call(arguments, 2))
+    childElements = toVdom.recursive(callFunctionsIn(Array.prototype.slice.call(arguments, 2)))
     prepareAttributes(selector, attributes, childElements)
-    tag = parseTag(selector, attributes)
-    vdom = vhtml(tag, attributes, childElements)
   } else {
     attributes = {}
-    childElements = toVdom.recursive(Array.prototype.slice.call(arguments, 1))
-    tag = parseTag(selector, attributes)
-    vdom = vhtml(tag, attributes, childElements)
+    childElements = toVdom.recursive(callFunctionsIn(Array.prototype.slice.call(arguments, 1)))
   }
+
+  tag = parseTag(selector, attributes)
+  vdom = vhtml(tag, attributes, childElements)
 
   if (hasHierarchy) {
     for (var n = selectorElements.length - 2; n >= 0; n--) {
@@ -120,6 +119,13 @@ exports.html = function (hierarchySelector) {
   }
 
   return vdom
+}
+
+function callFunctionsIn (args) {
+  for (var i = 0; i < args.length; i++) {
+    if (typeof args[i] === 'function') args[i] = args[i]()
+  }
+  return args
 }
 
 exports.jsx = function (tag, attributes) {

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -300,6 +300,26 @@ describe('hyperdom', function () {
       expect(find('.haha').text()).to.equal('object {"name":"asdf"}')
     })
 
+    it('can render the result of calling a function', function () {
+      function render () {
+        return h('div.yeah', 'object ', function () { return { thats: 'right' } })
+      }
+
+      attach(render, {})
+
+      expect(find('.yeah').text()).to.equal('object {"thats":"right"}')
+    })
+
+    it('can render the result of calling a function when attributes are specified', function () {
+      function render () {
+        return h('div', { class: 'yeah' }, 'object ', function () { return { thats: 'correct' } })
+      }
+
+      attach(render, {})
+
+      expect(find('.yeah').text()).to.equal('object {"thats":"correct"}')
+    })
+
     describe('class', function () {
       it('accepts a string', function () {
         function render () {


### PR DESCRIPTION
This may be an edge case, what do you think?

If an argument to `hyperdom.html` is a function, then call it. Otherwise we need to do that in view components.

When we have a component with dynamic content as children, e.g.

```js
class App {
  constructor() {
    this._funkyBox = new FunkyBox(() => `Hello ${this._emailAddress}!`)
  }

  render() {
    return hyperdom.html('.app', this._funkyBox)
  }
}
```

...then we need to treat each child as maybe or maybe not a function, e.g.

```js
class FunkyBox {
  constructor(...children) {
    this._children = children.map(c => typeof c === 'function' ? c() : c)
  }

  render() {
    return hyperdom.html('div.funky', this._children)
  }
}
```

With this change, we can do this instead:

```js
class FunkyBox {
  constructor(...children) {
    this._children = children
  }

  render() {
    return hyperdom.html('div.funky', this._children)
  }
}
```