### PR TITLE
Render objects by calling .toString() on them

### DIFF
--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -300,6 +300,19 @@ describe('hyperdom', function () {
       expect(find('.haha').text()).to.equal('object {"name":"asdf"}')
     })
 
+    it('can render an object that implements toString()', function () {
+      function Foo () {}
+      Foo.prototype.toString = function () { return '[sausages]' }
+
+      function render () {
+        return h('div.haha', 'object ', new Foo())
+      }
+
+      attach(render, {})
+
+      expect(find('.haha').text()).to.equal('object [sausages]')
+    })
+
     describe('class', function () {
       it('accepts a string', function () {
         function render () {

--- a/toVdom.js
+++ b/toVdom.js
@@ -15,6 +15,8 @@ function toVdom (object) {
     return object
   } else if (typeof object.render === 'function') {
     return new Component(object)
+  } else if (typeof object.toString === 'function' && object.constructor !== Object) {
+    return new Vtext(String(object.toString()))
   } else {
     return new Vtext(JSON.stringify(object))
   }


### PR DESCRIPTION
I would like to pass objects into `hyperdom.html()` and have hyperdom call `.toString()` on those objects.

Hyperdom calls `JSON.stringify()` when it doesn't know what else to do with an object. This might be reasonable behaviour for primitive objects, so this change preserves that behaviour, but calls `.toString()` on user-defined types that implement `.toString()`