### PR TITLE
dont render false values

### DIFF
--- a/test/server/toHtmlSpec.js
+++ b/test/server/toHtmlSpec.js
@@ -29,6 +29,15 @@ describe('to html', function () {
     )
   })
 
+  it('does not render false', function () {
+    var vdom = {
+      render: function () {
+        return h('div', false && h('h1', 'haha'))
+      }
+    }
+    expect(toHtml(vdom)).to.equal('<div></div>')
+  })
+
   it('can render top-level model components to HTML', function () {
     var vdom = {
       render: function () {

--- a/vhtml.js
+++ b/vhtml.js
@@ -8,9 +8,11 @@ var softSetHook = require('virtual-dom/virtual-hyperscript/hooks/soft-set-hook.j
 
 module.exports = h
 
-function h (tagName, props, children) {
+function h (tagName, props, childElements) {
   var tag = tagName
-
+  var children = childElements.filter(function (element) {
+    return element.text !== 'false'
+  })
   // support keys
   if (props.hasOwnProperty('key')) {
     var key = props.key


### PR DESCRIPTION
- Hyperdom renders false values as the string `false` which means we are forced to use
`this._somethingIsDefined ? renderSomething() : undefined`

This PR ignores the `false` values and allows `this._somethingIsDefined && renderSomething()` like react