### PR TITLE
Refresh after promise rejection

### DIFF
--- a/refreshEventResult.js
+++ b/refreshEventResult.js
@@ -14,12 +14,14 @@ function refreshEventResult (result, mount, options) {
   var onlyRefreshAfterPromise = options && options.refresh === 'promise'
   var componentToRefresh = options && options.component
 
+  function handlePromiseResult (result) {
+    var opts = cloneOptions(options)
+    opts.refresh = undefined
+    refreshEventResult(result, mount, opts)
+  }
+
   if (result && typeof (result.then) === 'function') {
-    result.then(function (result) {
-      var opts = cloneOptions(options)
-      opts.refresh = undefined
-      refreshEventResult(result, mount, opts)
-    })
+    result.then(handlePromiseResult, handlePromiseResult)
   }
 
   if (onlyRefreshAfterPromise) {

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -781,6 +781,32 @@ describe('hyperdom', function () {
       })
     })
 
+    it('refreshes the dom after an event handler promise rejects', function () {
+      function render (model) {
+        function onclick (e) {
+          e.preventDefault()
+          return new Promise(function (resolve, reject) {
+            setTimeout(function () {
+              model.mood = 'sad :('
+              reject(new Error('oops'))
+            }, 2)
+          })
+        }
+
+        return h('.app',
+          h('pre', model.mood),
+          h('button', { onclick: onclick }, 'Swing'))
+      }
+
+      attach(render, { mood: 'happy :)' })
+
+      return click('button').then(function () {
+        return retry(function () {
+          expect(find('pre').text()).to.eql('sad :(')
+        })
+      })
+    })
+
     it('can define event handlers outside of the render loop', function () {
       var model = {
         button: h('button', {


### PR DESCRIPTION
Lots of our event handlers call functions that can fail for a variety of reasons. We have "global" error interception that shows a banner at the top of any page when an unexpected error occurs.

However, if we leave our event handlers to reject their promises then hyperdom doesn't render anything generated by this global error handler.

I think we want to leave our event handlers to reject promises, so that we get error reporting from third-party libraries, and we see those errors in developer tools. Maybe there’s a different way of achieving that?

But it seems to me that regardless of whether an event handler promise is resolved or rejected, the model may be updated before that happens, and the view should therefore be refreshed. Otherwise the view is just out of date, and will change anyway next time it is refreshed for some other reason.

Is this sane? Am I missing something?