### PR TITLE
Rethrow event handler promise rejection error

### DIFF
--- a/refreshEventResult.js
+++ b/refreshEventResult.js
@@ -21,7 +21,10 @@ function refreshEventResult (result, mount, options) {
   }
 
   if (result && typeof (result.then) === 'function') {
-    result.then(handlePromiseResult, handlePromiseResult)
+    result.then(handlePromiseResult, function (error) {
+      handlePromiseResult(error)
+      throw error
+    })
   }
 
   if (onlyRefreshAfterPromise) {

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -782,13 +782,15 @@ describe('hyperdom', function () {
     })
 
     it('refreshes the dom after an event handler promise rejects', function () {
+      var sadError = new Error('so sad')
+
       function render (model) {
         function onclick (e) {
           e.preventDefault()
           return new Promise(function (resolve, reject) {
             setTimeout(function () {
               model.mood = 'sad :('
-              reject(new Error('oops'))
+              reject(sadError)
             }, 2)
           })
         }
@@ -800,9 +802,22 @@ describe('hyperdom', function () {
 
       attach(render, { mood: 'happy :)' })
 
+      var trapsUnhandledRejections = typeof window.onunhandledrejection !== 'undefined'
+      var unhandledError = 'expected-promise-rejection-error-to-be-rethrown'
+      function onUnhandledRejection (rejection) {
+        unhandledError = rejection.reason
+      }
+      if (trapsUnhandledRejections) {
+        window.addEventListener('unhandledrejection', onUnhandledRejection)
+      }
+
       return click('button').then(function () {
         return retry(function () {
           expect(find('pre').text()).to.eql('sad :(')
+          if (trapsUnhandledRejections) {
+            window.removeEventListener('unhandledrejection', onUnhandledRejection)
+            expect(unhandledError).to.eql(sadError)
+          }
         })
       })
     })

--- a/test/browser/hyperdomSpec.js
+++ b/test/browser/hyperdomSpec.js
@@ -807,6 +807,11 @@ describe('hyperdom', function () {
       function onUnhandledRejection (rejection) {
         unhandledError = rejection.reason
       }
+      function removeHandler () {
+        if (trapsUnhandledRejections) {
+          window.removeEventListener('unhandledrejection', onUnhandledRejection)
+        }
+      }
       if (trapsUnhandledRejections) {
         window.addEventListener('unhandledrejection', onUnhandledRejection)
       }
@@ -815,11 +820,10 @@ describe('hyperdom', function () {
         return retry(function () {
           expect(find('pre').text()).to.eql('sad :(')
           if (trapsUnhandledRejections) {
-            window.removeEventListener('unhandledrejection', onUnhandledRejection)
             expect(unhandledError).to.eql(sadError)
           }
         })
-      })
+      }).then(removeHandler, removeHandler)
     })
 
     it('can define event handlers outside of the render loop', function () {


### PR DESCRIPTION
We recently made a change where [promise rejections in event handlers cause a refresh](https://github.com/featurist/hyperdom/pull/108)

But it's useful if they also get thrown as "unhandled rejections" so you can see them in test failures, developer tools and trap them in supported browsers.

This change rethrows the error, which is what used to happen before that bug fix.

