### PR TITLE
Don't render false

### DIFF
--- a/prepareAttributes.js
+++ b/prepareAttributes.js
@@ -62,6 +62,10 @@ module.exports = function (tag, attributes, childElements) {
     attributes.className = generateClassName(attributes.className)
   }
 
+  if (attributes.innerHTML === false) {
+    delete attributes.innerHTML
+  }
+
   return attributes
 }
 

--- a/test/browser/hyperdomSpec.ts
+++ b/test/browser/hyperdomSpec.ts
@@ -279,6 +279,7 @@ describe('hyperdom', function () {
     itCanRenderA('boolean', true)
     itCanRenderA('date', new Date())
     itCanRenderA('undefined', undefined, '')
+    itCanRenderA('false', false, '')
 
     it('can render an object', function () {
       function render () {
@@ -471,6 +472,16 @@ describe('hyperdom', function () {
             })
           })
         })
+      })
+
+      it('renders false as empty string', function () {
+        function render () {
+          return hyperdom.rawHtml('.raw', false)
+        }
+
+        attach(render, {text: 'one'})
+
+        expect(find('.raw').text()).to.eql('')
       })
 
       it('renders undefined as empty string', function () {

--- a/toVdom.js
+++ b/toVdom.js
@@ -3,7 +3,7 @@ var isVdom = require('./isVdom')
 var Component = require('./component')
 
 function toVdom (object) {
-  if (object === undefined || object === null) {
+  if (object === undefined || object === null || object === false) {
     return new Vtext('')
   } else if (typeof (object) !== 'object') {
     return new Vtext(String(object))


### PR DESCRIPTION
So that people can write `isThing && <div>thing<div>` instead of `isThing ? <div>thing</div> : undefined`