### PR TITLE
router calls decodeURIComponent on each path param

### DIFF
--- a/router.js
+++ b/router.js
@@ -209,7 +209,7 @@ RouteDefinition.prototype.params = function (_url, _match) {
 
   if (match) {
     for (var n = 1; n < match.length; n++) {
-      params[this.variables[n - 1]] = match[n]
+      params[this.variables[n - 1]] = decodeURIComponent(match[n])
     }
     return params
   }

--- a/test/browser/routerSpec.ts
+++ b/test/browser/routerSpec.ts
@@ -389,9 +389,9 @@ function describeRouter (historyApiType: string) {
             app.refresh()
             return loadsArticle(monkey, app.article, 'y')
           }).then(function () {
-            route.push({id: 'z'})
+            route.push({id: 'id with spaces'})
             app.refresh()
-            return loadsArticle(monkey, app.article, 'z')
+            return loadsArticle(monkey, app.article, 'id with spaces')
           })
         })
       })


### PR DESCRIPTION
When the router calls `onload()` on a route component, it decodes the query string parameters, but doesn't decode the path parameters.

This fixes that problem, so that path params can have e.g. whitespace in them.