### PR TITLE
make selects with optgroup work

### DIFF
--- a/bindModel.js
+++ b/bindModel.js
@@ -47,15 +47,19 @@ var inputTypeBindings = {
 
     var options = []
     children.forEach(function (child) {
-      if (child.tagName && child.tagName.toLowerCase() === 'optgroup') {
-        return child.children.filter(function (optChild) {
-          if (optChild.tagName && optChild.tagName.toLowerCase() === 'option') {
-            options.push(optChild)
-          }
-        })
-      }
-      if (child.tagName && child.tagName.toLowerCase() === 'option') {
-        options.push(child)
+      const tagName = child.tagName && child.tagName.toLowerCase()
+
+      switch (tagName) {
+        case 'optgroup':
+          child.children.forEach(function (optChild) {
+            if (optChild.tagName && optChild.tagName.toLowerCase() === 'option') {
+              options.push(optChild)
+            }
+          })
+          break
+        case 'option':
+          options.push(child)
+          break
       }
     })
 

--- a/bindModel.js
+++ b/bindModel.js
@@ -45,8 +45,18 @@ var inputTypeBindings = {
   select: function (attributes, children, binding) {
     var currentValue = binding.get()
 
-    var options = children.filter(function (child) {
-      return child.tagName && child.tagName.toLowerCase() === 'option'
+    var options = []
+    children.forEach(function (child) {
+      if (child.tagName && child.tagName.toLowerCase() === 'optgroup') {
+        return child.children.filter(function (optChild) {
+          if (optChild.tagName && optChild.tagName.toLowerCase() === 'option') {
+            options.push(optChild)
+          }
+        })
+      }
+      if (child.tagName && child.tagName.toLowerCase() === 'option') {
+        options.push(child)
+      }
     })
 
     var values = []

--- a/test/browser/hyperdomSpec.ts
+++ b/test/browser/hyperdomSpec.ts
@@ -1287,6 +1287,51 @@ describe('hyperdom', function () {
         })
       })
 
+      it('can bind to select optgroup', function () {
+        const blue = { name: 'blue' }
+
+        const app = new class extends RenderComponent {
+          public colour = blue
+
+          public render () {
+            return h('div',
+              h('select',
+                {binding: [this, 'colour']},
+                h('optgroup', {label: 'common'}, [
+                  h('option.red', {value: 'red'}, 'red'),
+                  h('option.blue', {value: blue}, 'blue')
+                ]),
+              ),
+              h('span', JSON.stringify(this.colour)),
+            )
+          }
+        }()
+
+        attach(app)
+
+        return retry(function () {
+          expect(find('span').text()).to.equal('{"name":"blue"}')
+          expect(find('option.red').prop('selected')).to.equal(false)
+          expect(find('option.blue').prop('selected')).to.equal(true)
+        }).then(function () {
+          (find('select')[0] as HTMLSelectElement).selectedIndex = 0
+          find('select').change()
+
+          return retry(function () {
+            expect(find('span').text()).to.equal('"red"')
+            expect(find('option.red').prop('selected')).to.equal(true)
+          }).then(function () {
+            (find('select')[0] as HTMLSelectElement).selectedIndex = 1
+            find('select').change()
+
+            return retry(function () {
+              expect(find('span').text()).to.equal('{"name":"blue"}')
+              expect(find('option.blue').prop('selected')).to.equal(true)
+            })
+          })
+        })
+      })
+
       it('can render select with text nodes', function () {
         const app = new class extends RenderComponent {
           public colour = 'red'


### PR DESCRIPTION
Currently the binding code looks for options that are a direct descendent of a select box.
However options can be nested within an `optgroup`. Change the code to also look at these groups for options.